### PR TITLE
Change memory style

### DIFF
--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -337,9 +337,9 @@ $strings.gpu = if ($configuration.HasFlag([Configuration]::Show_GPU)) {
 # ===== MEMORY =====
 $strings.memory = if ($configuration.HasFlag([Configuration]::Show_Memory)) {
     $m = Get-CimInstance -ClassName Win32_OperatingSystem -Property TotalVisibleMemorySize,FreePhysicalMemory -CimSession $cimSession
-    $total = [math]::floor(($m.TotalVisibleMemorySize / 1mb))
-    $used = [math]::floor((($m.FreePhysicalMemory - $total) / 1mb))
-    ("{0}GiB / {1}GiB" -f $used,$total)
+    $total = $m.TotalVisibleMemorySize / 1mb
+    $used = ($m.TotalVisibleMemorySize - $m.FreePhysicalMemory) / 1mb
+    ("{0:f1} GiB / {1:f1} GiB" -f $used,$total)
 } else {
     $disabled
 }


### PR DESCRIPTION
Changes the memory info style to be "used / total" and rounds it to 1 decimal place. 

```
# before
Memory: 6GiB / 15GiB

# after
Memory: 9.5 GiB / 15.9 GiB
```

Fixes #19