### PR TITLE
Provide more specific OS info

### DIFF
--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -237,7 +237,8 @@ else {
 # ===== OS =====
 $strings.os = if ($configuration.HasFlag([Configuration]::Show_OS)) {
     if ($IsWindows -or $PSVersionTable.PSVersion.Major -eq 5) {
-        [Environment]::OSVersion.ToString().TrimStart('Microsoft ')
+        $os = Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption,OSArchitecture,Version -CimSession $cimSession
+        "$($os.Caption.TrimStart('Microsoft ')) [$($os.OSArchitecture)] ($($os.Version))"
     } else {
         ($PSVersionTable.OS).TrimStart('Microsoft ')
     }


### PR DESCRIPTION
Uses `Get-CimInstance` to retrieve more specific information on the operating system, compared to `[Environment]::OSVersion`.

Before:
![before](https://user-images.githubusercontent.com/39120423/99512561-b79d9080-29dd-11eb-9d1f-ebffaacb6afa.png)
After:
![after](https://user-images.githubusercontent.com/39120423/99512478-9c328580-29dd-11eb-9e49-b0a947a73e58.png)

Let me know if you want to use a different style.

Also, I was thinking we may want to break the `10.0.19041` into its own `Kernel` field as neofetch does, but I'm delaying that for now as I'm planning a change to the config.