### PR TITLE
Add motherboard, battery and IP information

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -19,6 +19,7 @@
     "dashes"
     "os"
     "computer"
+    "motherboard"
     # "custom_time"  # use custom info line
     "uptime"
     "pkgs"
@@ -28,6 +29,9 @@
     "gpu"
     "memory"
     # "disk"
+    # "battery"
+    # "local_ip"
+    # "public_ip"
     "blank"
     "colorbar"
 )

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -443,9 +443,17 @@ function info_local_ip {
 }
 
 function info_public_ip {
+    try {
+        $public_ip = (Resolve-DnsName -Name myip.opendns.com -Server resolver1.opendns.com).IPAddress
+    } catch {}
+
+    if (-not $public_ip) {
+        $public_ip = Invoke-RestMethod -Uri https://ifconfig.me/ip
+    }
+
     return @{
         title = "Public IP"
-        content = (Resolve-DnsName -Name myip.opendns.com -Server resolver1.opendns.com).IPAddress
+        content = $public_ip
     }
 }
 

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -113,6 +113,7 @@ $baseConfig = @(
     "dashes"
     "os"
     "computer"
+    "motherboard"
     "uptime"
     "pkgs"
     "pwsh"
@@ -121,6 +122,9 @@ $baseConfig = @(
     "gpu"
     "memory"
     "disk"
+    "battery"
+    "local_ip"
+    "public_ip"
     "blank"
     "colorbar"
 )

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -245,6 +245,16 @@ function info_os {
 }
 
 
+# ===== MOTHERBOARD =====
+function info_motherboard {
+    $motherboard = Get-CimInstance Win32_BaseBoard -CimSession $cimSession -Property Manufacturer,Product
+    return @{
+        title = "Motherboard"
+        content = "{0} {1}" -f $motherboard.Manufacturer, $motherboard.Product
+    }
+}
+
+
 # ===== TITLE =====
 function info_title {
     return @{

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -428,6 +428,24 @@ function info_battery {
 }
 
 
+# ===== IP =====
+function info_local_ip {
+    $indexDefault = Get-NetRoute -DestinationPrefix 0.0.0.0/0 | Sort-Object -Property RouteMetric | Select-Object -First 1 | Select-Object -ExpandProperty ifIndex
+    $local_ip = Get-NetIPAddress -AddressFamily IPv4 -InterfaceIndex $indexDefault | Select-Object -ExpandProperty IPAddress
+    return @{
+        title = "Local IP"
+        content = $local_ip
+    }
+}
+
+function info_public_ip {
+    return @{
+        title = "Public IP"
+        content = (Resolve-DnsName -Name myip.opendns.com -Server resolver1.opendns.com).IPAddress
+    }
+}
+
+
 # reset terminal sequences and display a newline
 Write-Host "$e[0m"
 

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -421,8 +421,8 @@ function info_battery {
 
     if (-not $battery) {
         return @{
-        title = "Battery"
-        content = "(none)"
+            title = "Battery"
+            content = "(none)"
         }
     }
 

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -411,6 +411,23 @@ function info_pkgs {
 }
 
 
+# ===== BATTERY =====
+function info_battery {
+    $battery = (Get-CimInstance Win32_Battery -CimSession $cimSession -Property EstimatedChargeRemaining).EstimatedChargeRemaining
+
+    $content = if ($battery) {
+        "$battery %"
+    } else {
+        "(none)"
+    }
+
+    return @{
+        title = "Battery"
+        content = $content
+    }
+}
+
+
 # reset terminal sequences and display a newline
 Write-Host "$e[0m"
 


### PR DESCRIPTION
Adds `motherboard`, `battery`, `local_ip` and `public_ip` info lines.

I decided to make these additions one PR as the four new info lines are quite straightforward changes, but I'm happy to break it up too.