### PR TITLE
Allow disk info to show multiple disks

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -11,6 +11,12 @@
 #     }
 # }
 
+# Configure which disks are shown
+# $ShowDisks = @("C:", "D:")
+# Show all available disks
+# $ShowDisks = @("*")
+
+
 # Remove the '#' from any of the lines in
 # the following to **enable** their output.
 

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -471,13 +471,13 @@ foreach ($item in $config) {
     }
 
     foreach ($line in $info) {
-        $output = "$e[1;34m$($line.title)$e[0m"
+        $output = "$e[1;34m$($line["title"])$e[0m"
 
-        if ($line.title -and $line.content) {
+        if ($line["title"] -and $line["content"]) {
             $output += ": "
         }
 
-        $output += "$($line.content)`n"
+        $output += "$($line["content"])`n"
 
         # move cursor to column 40
         if ($img) {

--- a/src/posh-winfetch.ps1
+++ b/src/posh-winfetch.ps1
@@ -430,6 +430,7 @@ foreach ($line in $img) {
 # move cursor to top of image and to column 40
 if ($img) {
     Write-Host -NoNewLine "$e[$($img.Length)A$e[40G"
+    $writtenLines = 0
 }
 
 # write info
@@ -444,25 +445,32 @@ foreach ($item in $config) {
         continue
     }
 
-    $output = "$e[1;34m$($info.title)$e[0m"
-
-    if ($info.title -and $info.content) {
-        $output += ": "
+    if ($info -isnot [array]) {
+        $info = @($info)
     }
 
-    $output += "$($info.content)`n"
+    foreach ($line in $info) {
+        $output = "$e[1;34m$($line.title)$e[0m"
 
-    # move cursor to column 40
-    if ($img) {
-        $output += "$e[40G"
+        if ($line.title -and $line.content) {
+            $output += ": "
+        }
+
+        $output += "$($line.content)`n"
+
+        # move cursor to column 40
+        if ($img) {
+            $output += "$e[40G"
+            $writtenLines++
+        }
+
+        Write-Host -NoNewLine $output
     }
-
-    Write-Host -NoNewLine $output
 }
 
 # move cursor back to the bottom
 if ($img) {
-    Write-Host -NoNewLine "$e[$($img.Length - $config.Length)B"
+    Write-Host -NoNewLine "$e[$($img.Length - $writtenLines)B"
 }
 
 # print 2 newlines


### PR DESCRIPTION
This PR has 3 parts to it:
* Update the printing method to allow info functions to display multiple lines, by returning an array of hashtables.

* Update the disk info function so that it can display multiple disks, configured by the `$ShowDisks` configuration option.

* Fix errors when using strict-mode (fixes #40)

![image](https://user-images.githubusercontent.com/39120423/105576791-52915d00-5dc9-11eb-9876-91e1ac93f3d1.png)

```pwsh
# Configure which disks are shown
# $ShowDisks = @("C:", "D:")

# Show all available disks
# $ShowDisks = @("*")
```
