### PR TITLE
Improve packages speed

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -22,6 +22,10 @@
 # Show all available disks
 # $ShowDisks = @("*")
 
+# Configure which package managers are shown
+# disabling unused ones will improve speed
+# $ShowPkgs = @("scoop", "choco")
+
 
 # Remove the '#' from any of the lines in
 # the following to **enable** their output.


### PR DESCRIPTION
This is my first attempt at improving the speed of the packages info. This is done by allowing users to disable unused package managers, and checking the default installation directory for `scoop` first.

The use of `Get-Command` takes around 160ms when it fails, this is mostly unavoidable unless we manually search the path ourselves, which is why I added the configuration option.

There are some other things I may look into in the future for `scoop` such as checking environment variables or the `scoop` config.