### PR TITLE
Replace Write-Host

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -624,18 +624,19 @@ function info_public_ip {
     }
 }
 
+$finaloutput = ""
 
 # reset terminal sequences and display a newline
-Write-Host "$e[0m"
+$finaloutput += "$e[0m" + [Environment]::newline
 
 # write logo
 foreach ($line in $img) {
-    Write-Host " $line"
+    $finaloutput += " $line" + [Environment]::newline
 }
 
 # move cursor to top of image and to column 40
 if ($img) {
-    Write-Host -NoNewLine "$e[$($img.Length)A$e[40G"
+    $finaloutput += "$e[$($img.Length)A$e[40G"
     $writtenLines = 0
 }
 
@@ -670,17 +671,19 @@ foreach ($item in $config) {
             $writtenLines++
         }
 
-        Write-Host -NoNewLine $output
+        $finaloutput += $output
     }
 }
 
 # move cursor back to the bottom
 if ($img) {
-    Write-Host -NoNewLine "$e[$($img.Length - $writtenLines)B"
+    $finaloutput += "$e[$($img.Length - $writtenLines)B"
 }
 
 # print 2 newlines
-Write-Host "`n"
+$finaloutput += [Environment]::newline
+
+return $finaloutput
 
 #  ___ ___  ___
 # | __/ _ \| __|

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -54,6 +54,8 @@
     Use legacy Windows logo.
 .PARAMETER blink
     Make the logo blink.
+.PARAMETER stripansi
+    Output without any text effects or colors.
 .PARAMETER help
     Display this help message.
 .INPUTS
@@ -70,10 +72,12 @@ param(
     [switch][alias('n')]$noimage,
     [switch][alias('l')]$legacylogo,
     [switch][alias('b')]$blink,
+    [switch][alias('s')]$stripansi,
     [switch][alias('h')]$help
 )
 
 $e = [char]0x1B
+$ansiRegex = '[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[-a-zA-Z\d\/#&.:=?%@~_]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-ntqry=><~]))'
 
 $is_pscore = $PSVersionTable.PSEdition.ToString() -eq 'Core'
 
@@ -682,6 +686,10 @@ if ($img) {
 
 # print 2 newlines
 $finaloutput += [Environment]::newline
+
+if ($stripansi) {
+    return $finaloutput -replace $ansiRegex, ''
+}
 
 return $finaloutput
 


### PR DESCRIPTION
Basically the title, for now.

Using `Write-Host` has historically been considered a bad practice. It forces output on the console, doesn't allow object/string manipulation, ignores pipelines and cannot be redirected. Here are a couple links, including one by Jeffrey Snover (creator of PowerShell) himself - 
https://www.jsnover.com/blog/2013/12/07/write-host-considered-harmful
https://pramodsingla.com/2015/11/20/powershell-do-not-use-write-host

For now, this commit doesn't do any changes, everything in the console output is the same. In fact, it adds some useful under-the-hood features, like manipulating winfetch's output, passing to pipeline (for example, to 'rainbow' (lolcat for Windows)), redirecting the output to a file using `| Out-File abc.txt` (more on this below), and use in scriptblocks like `Measure-Command`. None of this was possible with `Write-Host`. Not to mention that this new method is theoretically *faster*, since it's doing Console API call only once, as opposed to a large number of `Write-Host`s.

Something that I plan to implement in the near future: A function for stripping ANSI codes from a string. Searching on the internet, the basic premise of doing this is by regular expression replacement. This function will serve 2 purposes:
  1. Allow us to calculate actual text length beforehand so that #39 can be implemented. This was not possible before, as everything was being forced on the console with `Write-Host` and nothing was being stored.
  2. The output redirection (for example to a file), as of now with this commit, includes all the ANSI codes, making the output harder to read. I will include a commandline switch (like `-stripansi`) that we can use to output plaintext, that can be stored as-is in files.