### PR TITLE
Add -all parameter

### DIFF
--- a/lib/config.ps1
+++ b/lib/config.ps1
@@ -9,6 +9,9 @@
 # Make the logo blink
 # $blink = $true
 
+# Display all built-in info segments.
+# $all = $true
+
 # Add a custom info line
 # function info_custom_time {
 #     return @{

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -59,6 +59,8 @@
     Make the logo blink.
 .PARAMETER stripansi
     Output without any text effects or colors.
+.PARAMETER all
+    Display all built-in info segments.
 .PARAMETER help
     Display this help message.
 .PARAMETER showdisks
@@ -81,6 +83,7 @@ param(
     [switch][alias('l')]$legacylogo,
     [switch][alias('b')]$blink,
     [switch][alias('s')]$stripansi,
+    [switch][alias('a')]$all,
     [switch][alias('h')]$help,
     [array]$showdisks = @($env:SystemDrive),
     [array]$showpkgs = @("scoop", "choco")
@@ -166,7 +169,7 @@ if ((Get-Item -Path $configPath).Length -gt 0) {
     $config = . $configPath
 }
 
-if (-not $config) {
+if (-not $config -or $all) {
     $config = $baseConfig
 }
 


### PR DESCRIPTION
Adds a parameter `-all` which will enable/display all info segments. Pretty useful if you just want all information without having to edit your config.