### PR TITLE
scoop-search compatible

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -675,7 +675,7 @@ function info_pkgs {
         if (Test-Path "~/scoop/apps") {
             $scoopdir = "~/scoop/apps"
         } elseif (Get-Command -Name scoop -ErrorAction Ignore) {
-            $scoop = & scoop which scoop
+            $scoop = & scoop which scoop.ps1
             $scoopdir = (Resolve-Path "$(Split-Path -Path $scoop)\..\..\..").Path
         }
 


### PR DESCRIPTION
When use [scoop-search](https://github.com/shilangyu/scoop-search) with `Invoke-Expression (&scoop-search --hook)` in $profile as suggested in their readme, winfetch will throw errors as following.

![image](https://user-images.githubusercontent.com/30398651/115805060-0a1e1700-a399-11eb-9056-e3bd2a9533dc.png)

This error might because `scoop which scoop` return no result. I'm not sure why it returns no result but this PR is an easy workaround as shown below.
```
PS C:\Users\Gzl> scoop which scoop
Not a scoop shim.

PS C:\Users\Gzl> scoop which scoop.ps1
D:\Program Files\Scoop\apps\scoop\current\bin\scoop.ps1
```
