### PR TITLE
fix battery display greater than 100%

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -675,7 +675,7 @@ function info_pkgs {
         if (Test-Path "~/scoop/apps") {
             $scoopdir = "~/scoop/apps"
         } elseif (Get-Command -Name scoop -ErrorAction Ignore) {
-            $scoop = & scoop which scoop.ps1
+            $scoop = & scoop which scoop
             $scoopdir = (Resolve-Path "$(Split-Path -Path $scoop)\..\..\..").Path
         }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -675,7 +675,7 @@ function info_pkgs {
         if (Test-Path "~/scoop/apps") {
             $scoopdir = "~/scoop/apps"
         } elseif (Get-Command -Name scoop -ErrorAction Ignore) {
-            $scoop = & scoop which scoop
+            $scoop = & scoop which scoop.ps1
             $scoopdir = (Resolve-Path "$(Split-Path -Path $scoop)\..\..\..").Path
         }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -733,9 +733,15 @@ function info_battery {
         ", ${hours}h ${minutes}m"
     }
 
+    $chargeRemaining = if ($battery.EstimatedChargeRemaining -ge 100) {
+        100 
+    } else {
+        $battery.EstimatedChargeRemaining
+    }
+
     return @{
         title = "Battery"
-        content = get_level_info "  " $batterystyle $battery.EstimatedChargeRemaining "$status$timeFormatted" -altstyle
+        content = get_level_info "  " $batterystyle $chargeRemaining "$status$timeFormatted" -altstyle
     }
 }
 


### PR DESCRIPTION
`$battery.EstimatedChargeRemaining` can be greater than 100 before PR:
![Screenshot 2021-04-22 195530](https://user-images.githubusercontent.com/30398651/115812725-b286a800-a3a6-11eb-8c1f-fa3ae07cbb01.jpg)
after PR:
![Screenshot 2021-04-22 195600](https://user-images.githubusercontent.com/30398651/115812749-bc101000-a3a6-11eb-8adb-b87abbea4f93.jpg)

I don't know if there's any lambda expression in powershell. If there is, the code can be more condensed.

