### PR TITLE
New CPU Usage Retrieval and Process Counting Method

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -200,7 +200,7 @@ $defaultConfig = @'
     # "theme"
     "cpu"
     "gpu"
-    # "cpu_usage"  # takes some time
+    # "cpu_usage"
     "memory"
     "disk"
     # "battery"
@@ -715,32 +715,27 @@ function info_gpu {
 
 # ===== CPU USAGE =====
 function info_cpu_usage {
-    # Gets the number of logical processors in the system
-    $CPUs   = [System.Environment]::ProcessorCount
+    # Get all running processes and assign to a variable to allow reuse
+    $processes = [System.Diagnostics.Process]::GetProcesses()
+    $loadpercent = 0
+    $proccount = $processes.Count
+    # Get the number of logical processors in the system
+    $CPUs = [System.Environment]::ProcessorCount
 
-    $loadPercent = 0
-
-    if (!$Processes) {
-        # Get all running processes and assign to a variable to allow reuse
-        $Processes = [diagnostics.process]::GetProcesses()
-    }
-
-    $Processes.ForEach{
+    $timenow = [System.Datetime]::Now
+    $processes.ForEach{
         if ($_.StartTime -gt 0) {
             # Replicate the functionality of New-Timespan
-            $TimeSpan = (([datetime]::Now).Subtract($_.StartTime)).TotalSeconds
+            $timespan = ($timenow.Subtract($_.StartTime)).TotalSeconds
 
             # Calculate the CPU usage of the process and add to the total
-            $loadPercent += $_.CPU * 100 / $TimeSpan / $CPUs
+            $loadpercent += $_.CPU * 100 / $timespan / $CPUs
         }
     }
 
-    # Get count of running processes
-    $procCount = $Processes.Count
-    
     return @{
         title   = "CPU Usage"
-        content = get_level_info "" $cpustyle $loadPercent "$procCount processes" -altstyles
+        content = get_level_info "" $cpustyle $loadpercent "$proccount processes" -altstyle
     }
 }
 


### PR DESCRIPTION
Implements a new method of CPU usage retrieval and process counting using .NET

- Uses `[diagnostics.process]::GetProcesses()` to get all running processes
  - Iterates through every process, and converts their CPU time to total CPU utilization using the logical processor count and a timespan of the current time and the processes' StartTime, and adds it to a total
    - I'm not exactly sure how this works yet
- Seems to be surprisingly accurate, but hard to test to what degree though due to CPU usage being quite volatile at small timescales
  - Likely accurate enough for this use case
- Might have some more room for optimization, but it is hard to tell as the tracer I use can't seem to decide what is the heaviest part of the process

- Gets the process count using the variable assigned to the output of `[diagnostics.process]::GetProcesses()`

Speed:
- PowerShell 5:
  - 1035ms → 177.2ms
    - 5.8x Faster
- PowerShell 7:
  - 1035ms → 27.18ms
    - 38x Faster

Bottlenecked Speed:
- PowerShell 5:
  - 1086ms → 658.76ms
    - 1.65x Faster
- PowerShell 7:
  - 1073ms → 121.75ms
    - 8.8x Faster