### PR TITLE
Faster CPU Name Retrieval Method

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -688,7 +688,7 @@ function info_theme {
 # ===== CPU/GPU =====
 function info_cpu {
     # Get CPU Information
-    $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $Computername).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
+    $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $env:COMPUTERNAME).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
     $cpuName = $cpu.GetValue("ProcessorNameString")
 
     # If the CPU name has the frequency in it, remove it

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -687,16 +687,20 @@ function info_theme {
 
 # ===== CPU/GPU =====
 function info_cpu {
-    $cpu = Get-CimInstance -ClassName Win32_Processor -Property Name,MaxClockSpeed -CimSession $cimSession
-    $cpuname = if ($cpu.Name.Contains('@')) {
-        ($cpu.Name -Split ' @ ')[0].Trim()
+    # Get CPU Information
+    $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $Computername).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
+    $cpuName = $cpu.GetValue("ProcessorNameString")
+
+    # If the CPU name has the frequency in it, remove it
+    $cpuName = if ($cpuName -Contains '@') {
+        ($cpuName -Split ' @ ')[0].Trim()
     } else {
-        $cpu.Name.Trim()
+        $cpuName.Trim()
     }
-    $cpufreq = [math]::round((([int]$cpu.MaxClockSpeed)/1000), 2)
+
     return @{
         title   = "CPU"
-        content = "${cpuname} @ ${cpufreq}GHz"
+        content = "$cpuName @ $($cpu.GetValue("~MHz") / 1000)GHz" # [math]::Round($cpu.GetValue("~MHz") / 1000, 1) is 2-5ms slower
     }
 }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -689,18 +689,18 @@ function info_theme {
 function info_cpu {
     # Get CPU Information
     $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $env:COMPUTERNAME).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
-    $cpuName = $cpu.GetValue("ProcessorNameString")
+    $cpuname = $cpu.GetValue("ProcessorNameString")
 
     # If the CPU name has the frequency in it, remove it
-    $cpuName = if ($cpuName -Contains '@') {
-        ($cpuName -Split ' @ ')[0].Trim()
+    $cpuName = if ($cpuname -Contains '@') {
+        ($cpuname -Split '@')[0].Trim()
     } else {
-        $cpuName.Trim()
+        $cpuname.Trim()
     }
 
     return @{
         title   = "CPU"
-        content = "$cpuName @ $($cpu.GetValue("~MHz") / 1000)GHz" # [math]::Round($cpu.GetValue("~MHz") / 1000, 1) is 2-5ms slower
+        content = "$cpuname @ $($cpu.GetValue("~MHz") / 1000)GHz" # [math]::Round($cpu.GetValue("~MHz") / 1000, 1) is 2-5ms slower
     }
 }
 

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -687,17 +687,13 @@ function info_theme {
 
 # ===== CPU/GPU =====
 function info_cpu {
-    # Get CPU Information
-    $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $env:COMPUTERNAME).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
+    $cpu = [Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $Env:COMPUTERNAME).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")
     $cpuname = $cpu.GetValue("ProcessorNameString")
-
-    # If the CPU name has the frequency in it, remove it
-    $cpuName = if ($cpuname -Contains '@') {
+    $cpuname = if ($cpuname.Contains('@')) {
         ($cpuname -Split '@')[0].Trim()
     } else {
         $cpuname.Trim()
     }
-
     return @{
         title   = "CPU"
         content = "$cpuname @ $($cpu.GetValue("~MHz") / 1000)GHz" # [math]::Round($cpu.GetValue("~MHz") / 1000, 1) is 2-5ms slower


### PR DESCRIPTION
- Replaces the CIM method with one that uses the registry
  - Uses the keys `~MHz` and `ProcessorNameString` at `HKLM:\HARDWARE\DESCRIPTION\System\CentralProcessor\0`
    - Uses `[Microsoft.Win32.RegistryKey]::OpenRemoteBaseKey('LocalMachine', $Computername).OpenSubKey("HARDWARE\DESCRIPTION\System\CentralProcessor\0")` and `GetValue()` to get the registry keys much faster than using `Get-ItemProperty`
  - Currently doesn't round the frequency as rounding is slow

Speed :
- PowerShell 5:
  - 11.71ms → 4.99ms
    - 2.35x Faster
- PowerShell 7:
  - 12.18ms → 4.23ms
    - 2.88x Faster

Bottlenecked Speed:
- PowerShell 5:
  - 39.25ms → 20.28ms
    - 1.94x Faster
- PowerShell 7:
  - 29.43ms → 15.17ms
    - 1.94x Faster