### PR TITLE
Support for transparent images

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -293,6 +293,7 @@ $cimSession = New-CimSession
 $os = Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption,OSArchitecture,LastBootUpTime,TotalVisibleMemorySize,FreePhysicalMemory -CimSession $cimSession
 $t = if ($blink) { "5" } else { "1" }
 $COLUMNS = $imgwidth
+$aMin = $alphathreshold
 
 # ===== UTILITY FUNCTIONS =====
 function get_percent_bar {
@@ -395,31 +396,29 @@ $img = if (-not $noimage) {
                     $pixel1 = $Bitmap.GetPixel($j, $i)
                     $char = [char]0x2580
                     if ($i -ge $Bitmap.Height - 1) {
-                        if ($pixel1.A -lt $alphathreshold) {
+                        if ($pixel1.A -lt $aMin) {
                             $char = [char]0x2800
-                            $backVT = "$e[49m"
+                            $ansi = "$e[49m"
                         } else {
-                            $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
-                            $backVT = ""
+                            $ansi = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
                         }
                     } else {
                         $pixel2 = $Bitmap.GetPixel($j, $i + 1)
-                        if ($pixel1.A -lt $alphathreshold -or $pixel2.A -lt $alphathreshold) {
-                            $backVT = "$e[49m"
-                            if ($pixel1.A -lt $alphathreshold -and $pixel2.A -lt $alphathreshold) {
+                        if ($pixel1.A -lt $aMin -or $pixel2.A -lt $aMin) {
+                            if ($pixel1.A -lt $aMin -and $pixel2.A -lt $aMin) {
                                 $char = [char]0x2800
-                            } elseif ($pixel1.A -lt $alphathreshold) {
+                                $ansi = "$e[49m"
+                            } elseif ($pixel1.A -lt $aMin) {
                                 $char = [char]0x2584
-                                $foreVT = "$e[38;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
+                                $ansi = "$e[49;38;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
                             } else {
-                                $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
+                                $ansi = "$e[49;38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
                             }
                         } else {
-                            $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
-                            $backVT = "$e[48;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
+                            $ansi = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B);48;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
                         }
                     }
-                    $currline += "$backVT$foreVT$char$e[0m"
+                    $currline += "$ansi$char$e[0m"
                 }
                 $currline
             }

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -395,8 +395,13 @@ $img = if (-not $noimage) {
                     $pixel1 = $Bitmap.GetPixel($j, $i)
                     $char = [char]0x2580
                     if ($i -ge $Bitmap.Height - 1) {
-                        $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
-                        $backVT = ""
+                        if ($pixel1.A -lt $alphathreshold) {
+                            $char = [char]0x2800
+                            $backVT = "$e[49m"
+                        } else {
+                            $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
+                            $backVT = ""
+                        }
                     } else {
                         $pixel2 = $Bitmap.GetPixel($j, $i + 1)
                         if ($pixel1.A -lt $alphathreshold -or $pixel2.A -lt $alphathreshold) {

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -38,6 +38,8 @@
     Sets the version of Windows to derive the logo from.
 .PARAMETER imgwidth
     Specify width for image/logo. Default is 35.
+.PARAMATER alphathreshold
+    Specify minimum alpha value for image pixels to be visible. Default is 50.
 .PARAMETER blink
     Make the logo blink.
 .PARAMETER stripansi
@@ -82,6 +84,7 @@ param(
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$diskstyle = "text",
     [ValidateSet("text", "bar", "textbar", "bartext")][string]$batterystyle = "text",
     [ValidateScript({$_ -gt 1 -and $_ -lt $Host.UI.RawUI.WindowSize.Width-1})][alias('w')][int]$imgwidth = 35,
+    [ValidateScript({$_ -ge 0 -and $_ -le 255})][alias('t')][int]$alphathreshold = 50,
     [array]$showdisks = @($env:SystemDrive),
     [array]$showpkgs = @("scoop", "choco")
 )
@@ -117,6 +120,9 @@ $defaultConfig = @'
 
 # Specify width for image/logo
 # $imgwidth = 24
+
+# Specify minimum alpha value for image pixels to be visible
+# $alphathreshold = 50
 
 # Custom ASCII Art
 # This should be an array of strings, with positive

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -293,7 +293,6 @@ $cimSession = New-CimSession
 $os = Get-CimInstance -ClassName Win32_OperatingSystem -Property Caption,OSArchitecture,LastBootUpTime,TotalVisibleMemorySize,FreePhysicalMemory -CimSession $cimSession
 $t = if ($blink) { "5" } else { "1" }
 $COLUMNS = $imgwidth
-$aMin = $alphathreshold
 
 # ===== UTILITY FUNCTIONS =====
 function get_percent_bar {
@@ -396,7 +395,7 @@ $img = if (-not $noimage) {
                     $pixel1 = $Bitmap.GetPixel($j, $i)
                     $char = [char]0x2580
                     if ($i -ge $Bitmap.Height - 1) {
-                        if ($pixel1.A -lt $aMin) {
+                        if ($pixel1.A -lt $alphathreshold) {
                             $char = [char]0x2800
                             $ansi = "$e[49m"
                         } else {
@@ -404,11 +403,11 @@ $img = if (-not $noimage) {
                         }
                     } else {
                         $pixel2 = $Bitmap.GetPixel($j, $i + 1)
-                        if ($pixel1.A -lt $aMin -or $pixel2.A -lt $aMin) {
-                            if ($pixel1.A -lt $aMin -and $pixel2.A -lt $aMin) {
+                        if ($pixel1.A -lt $alphathreshold -or $pixel2.A -lt $alphathreshold) {
+                            if ($pixel1.A -lt $alphathreshold -and $pixel2.A -lt $alphathreshold) {
                                 $char = [char]0x2800
                                 $ansi = "$e[49m"
-                            } elseif ($pixel1.A -lt $aMin) {
+                            } elseif ($pixel1.A -lt $alphathreshold) {
                                 $char = [char]0x2584
                                 $ansi = "$e[49;38;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
                             } else {

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -386,15 +386,29 @@ $img = if (-not $noimage) {
             for ($i = 0; $i -lt $Bitmap.Height; $i += 2) {
                 $currline = ""
                 for ($j = 0; $j -lt $Bitmap.Width; $j++) {
-                    $back = $Bitmap.GetPixel($j, $i)
+                    $pixel1 = $Bitmap.GetPixel($j, $i)
+                    $char = [char]0x2580
                     if ($i -ge $Bitmap.Height - 1) {
-                        $foreVT = ""
+                        $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
+                        $backVT = ""
                     } else {
-                        $fore = $Bitmap.GetPixel($j, $i + 1)
-                        $foreVT = "$e[48;2;$($fore.R);$($fore.G);$($fore.B)m"
+                        $pixel2 = $Bitmap.GetPixel($j, $i + 1)
+                        if ($pixel1.A -lt $alphathreshold -or $pixel2.A -lt $alphathreshold) {
+                            $backVT = "$e[49m"
+                            if ($pixel1.A -lt $alphathreshold -and $pixel2.A -lt $alphathreshold) {
+                                $char = [char]0x2800
+                            } elseif ($pixel1.A -lt $alphathreshold) {
+                                $char = [char]0x2584
+                                $foreVT = "$e[38;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
+                            } else {
+                                $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
+                            }
+                        } else {
+                            $foreVT = "$e[38;2;$($pixel1.R);$($pixel1.G);$($pixel1.B)m"
+                            $backVT = "$e[48;2;$($pixel2.R);$($pixel2.G);$($pixel2.B)m"
+                        }
                     }
-                    $backVT = "$e[38;2;$($back.R);$($back.G);$($back.B)m"
-                    $currline += "$backVT$foreVT$([char]0x2580)$e[0m"
+                    $currline += "$backVT$foreVT$char$e[0m"
                 }
                 $currline
             }

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -38,7 +38,7 @@
     Sets the version of Windows to derive the logo from.
 .PARAMETER imgwidth
     Specify width for image/logo. Default is 35.
-.PARAMATER alphathreshold
+.PARAMETER alphathreshold
     Specify minimum alpha value for image pixels to be visible. Default is 50.
 .PARAMETER blink
     Make the logo blink.


### PR DESCRIPTION
Currently transparent pixels just show as black:

![image](https://user-images.githubusercontent.com/61563764/201246768-49114fb0-98f2-4784-a174-2ad64cf25aac.png)

This PR replaces transparent pixels with the terminal background:

![image](https://user-images.githubusercontent.com/61563764/201247044-633f2cf2-f112-4f4c-8c28-26095fbacc24.png)

I've also added an alphathreshold option which I found was useful for refining images with a mix of alpha values. If a pixel's alpha value is below the threshold it won't be visible.
