### PR TITLE
New IP Retreival Method

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -1452,7 +1452,7 @@ function info_public_ip {
                 $ErrorActionPreference = 'Continue'
             }
 
-            # Check if the public IP address was found
+            # Check if the public IP address was successfully retrieved
             if ($Global:public_ip) {
                 $public_ip
             } else {


### PR DESCRIPTION
- Replaced the implementations of `info_local_ip` and `info_public_ip` with a DNS lookup
  - Using `nslookup -type=a myip.opendns.com` gives both the public IP and local IP
    - The implementation is in an if statement within both functions that check if the global variable exists, which allows for both functions to be executed in any order
    - After some formatting, the public and private IPs are set to global variables to allow for reuse between function calls
- Added some new backup implementations that only return one of the IPs
  - `info_local_ip`:
    1. Creates and uses a network socket using `System.Net.Sockets`
      - Connects to `1.1.1.1` and gets the IP endpoint
        - Uses port `65530` but any port works in my testing
      - Executes in ~18ms (48ms on slow system)
        - ~2x Faster than the primary method on its own, but the speed gain of getting both IPs at once outweighs the speed gain of this method
        - [ ] Maybe: Find a way to check if `info_public_ip` is enabled
    2. Uses `System.Net.Dns` to perform a DNS lookup for `myip.opendns.com`
      - Most routers will process a DNS request for `myip.opendns.com` and return the sender's IP
        - Executes in 22ms (~58ms on slow system)
    3. Uses the old method of getting the IP information from the network adapter
  - `info_public_ip`:
    1. Uses the old method of querying `http://ifconfig.me/ip`
      - Replaced `Invoke RestMethod` with `[System.Net.WebClient]::new().DownloadString()`
        - ~10% Faster

Speed:
- Powershell 5:
  - Slow:
    - 371ms -> 80ms
      - 4.63x Faster
  - Fast:
    - 118ms -> 33ms
      - 3.58x Faster
- Powershell 7:
  - Slow:
    - 368ms -> 154ms
      - 2.39x Faster
  - Fast:
    - 129ms -> 45 ms
      - 2.87x Faster