### PR TITLE
Port to PowerShell 2

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -295,7 +295,7 @@ $COLUMNS = $imgwidth
 
 # ===== UTILITY FUNCTIONS =====
 function get_percent_bar {
-    param ([ValidateRange(0, 100)][int]$percent)
+    param ([Parameter(Mandatory = $true)][ValidateRange(0, 100)][int]$percent)
 
     $x = [char]9632
     $bar = $null


### PR DESCRIPTION
Due to the extensive changes to the script this required and the difficulty this would require to maintain, I strongly recommend this be merged into a new branch.

- Ported the script to PowerShell 2
  - Now theoretically compatible with Windows 7
    - Confirmed that it works in a VM, but it seems that a lot of the formatting and coloring that is done is not compatible with the PowerShell 2 terminal
  - Required changes to almost every function
  - Major Changes:
    - ErrorAction `Ignore` doesn't exist, so I replaced it with `SilentlyContinue`
    - Replaced `[String]::IsNullOrWhiteSpace()` with `[String]::IsNullOrEmpty()`
      - Might not work in the case the config file has only white space
    - `Get-CimInstance` and other CIM things were added in PowerShell 3, so they had to be replaced with their respective WMI versions
      - All returned values were identical except for `LastBootUpTime`, which I had to convert to a `DateTime` type
    - `$PSItem` doesn't seem to work quite right, so I replaced it with `$_`
    - `$PSVersionTable.PSEdition` doesn't exist, so I had to add another check to `info_terminal`
    - Replaced `-in` with `-contains`
    - Replaced `.ForEach` with `ForEach-Object`
    - `Get-Package` doesn't exist, so `Get-Module` is used if PowerShell 2 is detected
    - Replaced `Invoke-RestMethod` with `[System.Net.WebRequest]::Create()`
      - `[System.Net.WebRequest]::New()` doesn't exist
      - Seems to fail when `C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe.config` has something set from a more recent version of PowerShell