### PR TITLE
Fix custom image breaking when special characters are present in path

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -368,8 +368,8 @@ $img = if (-not $noimage) {
         }
 
         Add-Type -AssemblyName 'System.Drawing'
-        $OldImage = if (Test-Path $image -PathType Leaf) {
-            [Drawing.Bitmap]::FromFile((Resolve-Path $image))
+        $OldImage = if (Test-Path -LiteralPath $image -PathType Leaf) {
+            [Drawing.Bitmap]::FromFile((Resolve-Path -LiteralPath $image))
         } else {
             [Drawing.Bitmap]::FromStream((Invoke-WebRequest $image -UseBasicParsing).RawContentStream)
         }


### PR DESCRIPTION
Fix the custom image breaking when special characters (square brackets, others) are present in the `$image` path in the config file