### PR TITLE
removed "-l" arg from "choco list" for Chocolatey 2.0 compatibility

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -872,7 +872,7 @@ function info_pkgs {
     }
 
     if ("choco" -in $ShowPkgs -and (Get-Command -Name choco -ErrorAction Ignore)) {
-        $chocopkg = (& choco list -l)[-1].Split(' ')[0] - 1
+        $chocopkg = (& choco list)[-1].Split(' ')[0] - 1
 
         if ($chocopkg) {
             $pkgs += "$chocopkg (choco)"

--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -872,7 +872,9 @@ function info_pkgs {
     }
 
     if ("choco" -in $ShowPkgs -and (Get-Command -Name choco -ErrorAction Ignore)) {
-        $chocopkg = (& choco list)[-1].Split(' ')[0] - 1
+        $chocopkg = Invoke-Expression $(
+            "(& choco list" + $(if([version](& choco --version).Split('-')[0]`
+            -lt [version]'2.0.0'){" --local-only"}) + ")[-1].Split(' ')[0] - 1")
 
         if ($chocopkg) {
             $pkgs += "$chocopkg (choco)"


### PR DESCRIPTION
Running `choco list -l` on Chocolatey 2.0.0 produces the following error:
```Invalid argument -l. This argument has been removed from the list command and cannot be used.```
Removing the `-l` argument resolves the error and winfetch works properly again.
![image](https://github.com/lptstr/winfetch/assets/37491308/823fc0a9-2bf3-48c9-9a37-33bde0f3f483)

Closes #189
