### PR TITLE
Default Values for exceeding range 0-100 in `get_percent_bar`

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -296,7 +296,10 @@ $COLUMNS = $imgwidth
 
 # ===== UTILITY FUNCTIONS =====
 function get_percent_bar {
-    param ([Parameter(Mandatory)][ValidateRange(0, 100)][int]$percent)
+    param ([Parameter(Mandatory)][int]$percent)
+
+    if ($percent -gt 100) { $percent = 100 }
+    elseif ($percent -lt 0) { $percent = 0 }
 
     $x = [char]9632
     $bar = $null


### PR DESCRIPTION
More of a Temporary Fix for Issue: #181 ,
Where shortly after Startup the `cpu_usage` calculation gets a result above 100. 
With this change we could just simply escape the error by setting the Bar to 100% anyways.

To ensure no error occurs if range 0-100 is exceeded any value lesser than 0 gets defaulted to 0 aswell