### PR TITLE
Fixes package line sometimes showing '-1' for Chocolatey

### DIFF
--- a/winfetch.ps1
+++ b/winfetch.ps1
@@ -876,8 +876,8 @@ function info_pkgs {
 
     if ("choco" -in $ShowPkgs -and (Get-Command -Name choco -ErrorAction Ignore)) {
         $chocopkg = Invoke-Expression $(
-            "(& choco list" + $(if([version](& choco --version).Split('-')[0]`
-            -lt [version]'2.0.0'){" --local-only"}) + ")[-1].Split(' ')[0] - 1")
+            "((& choco list" + $(if([version](& choco --version).Split('-')[0]`
+            -lt [version]'2.0.0'){" --local-only"}) + ") | Select-String -Pattern '(\d+) packages installed\.').Matches[0].Groups[1].Value - 1")
 
         if ($chocopkg) {
             $pkgs += "$chocopkg (choco)"


### PR DESCRIPTION
Fixes an issue where an occasional advertisement when running `choco list` would cause the package count for Chocolatey to show -1, instead of the correct number.

![326943213-930b65cf-3667-4345-ae28-2b5d888a8c1e](https://github.com/lptstr/winfetch/assets/22787155/bae65eef-180c-4fe5-890e-0a451b796176)

#215
